### PR TITLE
add gitignore to exclude generated MSVS content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.vcxproj
+*.vcxproj.user
+*.vcxproj.filters
+*.sln


### PR DESCRIPTION
This makes the `script/boostrap.py --msvs` experience nicer for contributors by hiding the generated files.